### PR TITLE
Add city CRUD and navigation

### DIFF
--- a/controladores/ciudad.php
+++ b/controladores/ciudad.php
@@ -6,59 +6,37 @@ if (isset($_POST['guardar'])) {
     guardar($_POST['guardar']);
 }
 
-function guardar($lista) {
-    //crea un arreglo del texto que se le pasa
-    $json_datos = json_decode($lista, true);
-    $base_datos = new DB();
-    $query = $base_datos->conectar()->prepare("INSERT INTO `proveedor`
-    ( `nom_ape_prov`,
-     `razon_social_prov`, `telefono_prov`, 
-     `ruc_prov`, `direccion_prov`, `email_prov`, `estado`, 
-     `cod_ciudad`) VALUES (:nom_ape_prov, :telefono_prov, :ruc_prov, :direccion_prov, :email_prov , :estado, :cod_ciudad)");
-
-    $query->execute($json_datos);
+if (isset($_POST['ultimo_registro'])) {
+    ultimo_registro();
 }
 
-//-----------------------------------------------------------------------------------------------------
-//-----------------------------------------------------------------------------------------------------
-//-----------------------------------------------------------------------------------------------------
-
-if(isset($_POST['leer'])){
+if (isset($_POST['leer'])) {
     leer();
 }
 
-function leer(){
-    $base_datos = new DB();
-    $query = $base_datos->conectar()->prepare("SELECT `cod_proveedor`,
-     `nom_ape_prov`, `razon_social_prov`,
-     `telefono_prov`, `ruc_prov`, `direccion_prov`,
-      `email_prov`, `estado`,
-      `cod_ciudad` 
-      FROM `proveedor`");
-    
-    $query->execute();
-
-    if ($query->rowCount()) {
-        print_r(json_encode($query->fetchAll(PDO::FETCH_OBJ)));
-    } else {
-        echo '0';
-    }
-}
-//-----------------------------------------------------------------------------------
-//-----------------------------------------------------------------------------------
-//-----------------------------------------------------------------------------------
-if(isset($_POST['id'])){
+if (isset($_POST['id'])) {
     id($_POST['id']);
 }
 
-function id($id){
-    $base_datos = new DB();
-    $query = $base_datos->conectar()->prepare("SELECT `id_insumo`, `descripcion`,
-     `costo_compra`, `precio_venta`, `stock`, `stock_minimo`, `marca`, `estado` 
-    FROM `insumo`  WHERE id_insumo  = $id ");
-    
-    $query->execute();
+if (isset($_POST['actualizar'])) {
+    actualizar($_POST['actualizar']);
+}
 
+if (isset($_POST['eliminar'])) {
+    eliminar($_POST['eliminar']);
+}
+
+function guardar($lista) {
+    $json_datos = json_decode($lista, true);
+    $base_datos = new DB();
+    $query = $base_datos->conectar()->prepare("INSERT INTO ciudad (cod_ciudad, nombre_ciud, estado_ciud) VALUES (:cod_ciudad, :nombre_ciud, :estado_ciud)");
+    $query->execute($json_datos);
+}
+
+function ultimo_registro() {
+    $base_datos = new DB();
+    $query = $base_datos->conectar()->prepare("SELECT cod_ciudad FROM ciudad ORDER BY cod_ciudad DESC LIMIT 1");
+    $query->execute();
     if ($query->rowCount()) {
         print_r(json_encode($query->fetch(PDO::FETCH_OBJ)));
     } else {
@@ -66,76 +44,38 @@ function id($id){
     }
 }
 
-//----------------------------------------------------------------
-//----------------------------------------------------------------
-//----------------------------------------------------------------
-if(isset($_POST['actualizar'])){
-    actualizar($_POST['actualizar']);
-}
-
-function actualizar($lista){
-    $json_datos = json_decode($lista, true);
+function leer() {
     $base_datos = new DB();
-    $query = $base_datos->conectar()->prepare("UPDATE `insumo`
-     SET `descripcion`=:descripcion,`costo_compra`=:costo_compra,`precio_venta`=:precio_venta,
-     `stock`=:stock,`stock_minimo`=:stock_minimo,`marca`=:marca,`estado`=:estado
-     WHERE `id_insumo` = :id_insumo");
-
-    $query->execute($json_datos);
-}
-
-if(isset($_POST['eliminar'])){
-    eliminar($_POST['eliminar']);
-}
-
-function eliminar($id){
-   
-    $base_datos = new DB();
-    $query = $base_datos->conectar()->prepare("DELETE FROM `insumo` where id_insumo = $id");
-
+    $query = $base_datos->conectar()->prepare("SELECT cod_ciudad, nombre_ciud, estado_ciud FROM ciudad");
     $query->execute();
-}
-
-if (isset($_POST["leer_descripcion"])) {
-    
-    leer_descripcion($_POST["leer_descripcion"]);
-   }
-   function leer_descripcion ($descripcion){
-       $base = new DB();
-       $query = $base ->conectar()->prepare("SELECT id_insumo, descripcion, costo_compra, precio_venta, stock, stock_minimo, marca, estado
-FROM insumo
-WHERE CONCAT(id_insumo, descripcion, costo_compra, precio_venta, stock, stock_minimo, marca, estado) LIKE '%$descripcion%'
-ORDER BY id_insumo DESC
-LIMIT 50");
-       $query ->execute ();
-       
-      if ($query->rowCount()) {
-           print_r(json_encode($query->fetchAll(PDO::FETCH_OBJ)));
-       } else {
-           echo '0';
-       }
-   }
-
-   
-
-   if (isset($_POST['leer_ciudad_activos'])) {
-    leer_ciudad_activos();
-}
-
-function leer_ciudad_activos() {
-//    $json_datos = json_decode($lista, true);
-    $base_datos = new DB();
-
-    $query = $base_datos->conectar()->prepare(" SELECT `cod_ciudad`, 
-    `descripcion_ciud`, `estado` 
-    FROM `ciudad`
-");
-
-    $query->execute();
-
     if ($query->rowCount()) {
         print_r(json_encode($query->fetchAll(PDO::FETCH_OBJ)));
     } else {
         echo '0';
     }
 }
+
+function id($id) {
+    $base_datos = new DB();
+    $query = $base_datos->conectar()->prepare("SELECT cod_ciudad, nombre_ciud, estado_ciud FROM ciudad WHERE cod_ciudad = $id");
+    $query->execute();
+    if ($query->rowCount()) {
+        print_r(json_encode($query->fetch(PDO::FETCH_OBJ)));
+    } else {
+        echo '0';
+    }
+}
+
+function actualizar($lista) {
+    $json_datos = json_decode($lista, true);
+    $base_datos = new DB();
+    $query = $base_datos->conectar()->prepare("UPDATE ciudad SET nombre_ciud=:nombre_ciud, estado_ciud=:estado_ciud WHERE cod_ciudad=:cod_ciudad");
+    $query->execute($json_datos);
+}
+
+function eliminar($id) {
+    $base_datos = new DB();
+    $query = $base_datos->conectar()->prepare("DELETE FROM ciudad WHERE cod_ciudad = $id");
+    $query->execute();
+}
+?>

--- a/main.php
+++ b/main.php
@@ -404,6 +404,7 @@
                                     <li class="nav-item"> <a class="nav-link" href="#" onclick="mostrarListarEquipo();">Equipos</a></li>
                                     <li class="nav-item"> <a class="nav-link" href="#" onclick="mostrarListarCliente();">Cliente</a></li>
                                     <li class="nav-item"> <a class="nav-link" href="#" onclick="mostrarListarProveedores();">Proveedor</a></li>
+                                    <li class="nav-item"> <a class="nav-link" href="#" onclick="mostrarListarCiudad();">Ciudad</a></li>
                                 </ul>
                             </div>
                         </li>
@@ -677,6 +678,7 @@
         <script src="vista/proveedor.js"></script>
         <script src="vista/equipo.js"></script>
         <script src="vista/cliente.js"></script>
+        <script src="vista/ciudad.js"></script>
         <script src="vista/pedido.js"></script>
         <script src="vista/presupuesto.js"></script>
         <script src="vista/orden_compra.js"></script>

--- a/paginas/referenciales/ciudad/agregar.php
+++ b/paginas/referenciales/ciudad/agregar.php
@@ -1,0 +1,35 @@
+<div class="container-fluid card" style="padding: 30px; height: auto;" >
+    <div class="row">
+        <input type="text" value="0" id="id_ciudad" hidden>
+        <div class="col-md-12">
+            <h3>Agregar ciudad</h3>
+        </div>
+        <div class="col-md-12">
+            <hr>
+        </div>
+        <div class="col-md-1">
+            <label for="">Codigo</label>
+            <input type="text" id="cod" class="form-control" readonly>
+        </div>
+        <div class="col-md-5">
+            <label for="">Ciudad</label>
+            <input type="text" id="nombre_ciud" class="form-control">
+        </div>
+        <div class="col-md-5">
+            <label for="">Estado</label>
+            <select id="estado_ciud" class="form-control">
+                <option value="ACTIVO">ACTIVO</option>
+                <option value="INACTIVO">INACTIVO</option>
+            </select>
+        </div>
+        <div class="col-md-12">
+            <hr>
+        </div>
+        <div class="col-md-3">
+            <button class="form-control btn btn-success" onclick="guardarCiudad(); return false;"><i class="fa fa-save"></i> Guardar</button>
+        </div>
+        <div class="col-md-3">
+            <button class="form-control btn btn-danger" onclick="mostrarListarCiudad(); return false;"><i class="fa fa-ban"></i> Cancelar</button>
+        </div>
+    </div>
+</div>

--- a/paginas/referenciales/ciudad/listar.php
+++ b/paginas/referenciales/ciudad/listar.php
@@ -1,0 +1,26 @@
+<div class="container-fluid card" style="padding: 30px;">
+<div class="row">
+    <div class="col-md-10">
+        <h3>Lista de ciudades</h3>
+    </div>
+    <div class="col-md-2">
+        <button class="btn btn-primary " onclick="mostrarAgregarCiudad(); return false;"><i class="fa fa-plus"></i> Agregar</button>
+    </div>
+    <div class="col-md-12">
+        <hr>
+    </div>
+    <div class="col-md-12" style="margin-top: 30px;">
+        <table class="table table-bordered table-striped  table-head-bg-primary mt-4">
+            <thead>
+                <tr>
+                   <th>#</th>
+                    <th>Ciudad</th>
+                    <th>Estado</th>
+                    <th>Operaciones</th>
+                </tr>
+            </thead>
+            <tbody id="ciudad_tb"></tbody>
+        </table>
+    </div>
+</div>
+</div>

--- a/vista/ciudad.js
+++ b/vista/ciudad.js
@@ -1,86 +1,48 @@
-function mostrarListar() {
-    let contenido = dameContenido("paginas/referenciales/proveedores/listar.php");
+function mostrarListarCiudad() {
+    let contenido = dameContenido("paginas/referenciales/ciudad/listar.php");
     $(".contenido-principal").html(contenido);
-    cargarTablaProveedores("#proveedores_tb");
-    console.log(contenido);
-    //hola que tal?
+    cargarTablaCiudad();
 }
 //----------------------------------------------------------------------------
-//----------------------------------------------------------------------------
-//----------------------------------------------------------------------------
-function mostrarAgregar() {
-    let contenido = dameContenido("paginas/referenciales/proveedores/agregar.php");
+function mostrarAgregarCiudad() {
+    let contenido = dameContenido("paginas/referenciales/ciudad/agregar.php");
     $(".contenido-principal").html(contenido);
-}
-//---------------------------------------------------------------------------
-//---------------------------------------------------------------------------
-//---------------------------------------------------------------------------
-function cancelarInsumo() {
-    Swal.fire({
-        title: "Atencion",
-        text: "Desea cancelar la operacion?",
-        icon: "question",
-        showCancelButton: true,
-        confirmButtonColor: "#3085d6",
-        cancelButtonColor: "#d33",
-        cancelButtonText: "No",
-        confirmButtonText: "Si"
-    }).then((result) => {
-        if (result.isConfirmed) {
-            let contenido = dameContenido("paginas/referenciales/proveedores/listar.php");
-            $(".contenido-principal").html(contenido);
-            cargarTablaProveedores();
-        }
-    });
-
-}
-
-
-//-----------------------------------------------------------------------------
-//-----------------------------------------------------------------------------
-//-----------------------------------------------------------------------------
-function guardarProveedores() {
-
-   
-    
-
-    let data = {
-        'descripcion': $("#descripcion").val(),
-        'costo_compra': $("#costo_compra").val(),
-        'precio_venta': $("#precio_venta").val(),
-        'stock': $("#stock").val(),
-        'stock_minimo': $("#stock_minimo").val(),
-        'marca': $("#marca").val(),
-        'estado': $("#estado").val()
-        
-    };
-
-    
-    if($("#id_insumo").val() === "0"){
-        
-        let response = ejecutarAjax("controladores/insumo.php", "guardar=" + JSON.stringify(data));
-//        console.log(response);
-         mensaje_confirmacion("Guardado correctamente", "Guardado");
-//        mostrarListarInsumo();
-    }else{
-        data = {...data , 'id_insumo' : $("#id_insumo").val()};
-         let response = ejecutarAjax("controladores/insumo.php",
-         "actualizar=" + JSON.stringify(data));
-//        console.log(response);
-        mensaje_confirmacion("Actualizado Correctamente","Actualizado");
+    let ultimo = ejecutarAjax("controladores/ciudad.php", "ultimo_registro=1");
+    if (ultimo === "0") {
+        $("#cod").val("1");
+    } else {
+        let json_ultimo = JSON.parse(ultimo);
+        $("#cod").val(parseInt(json_ultimo['cod_ciudad']) + 1);
     }
-        $("#id_insumo").val("0");
-        mostrarListarInsumo();
-
-
+}
+//---------------------------------------------------------------------------
+function guardarCiudad() {
+    if ($("#nombre_ciud").val().trim().length === 0) {
+        mensaje_dialogo_info_ERROR("Atención", "Debes ingresar la descripción de la ciudad");
+        return false;
+    }
+    let data = {
+        'cod_ciudad': $("#cod").val(),
+        'nombre_ciud': $("#nombre_ciud").val(),
+        'estado_ciud': $("#estado_ciud").val()
+    };
+    if ($("#id_ciudad").val() === "0") {
+        ejecutarAjax("controladores/ciudad.php", "guardar=" + JSON.stringify(data));
+        mensaje_confirmacion("Guardado correctamente", "Guardado");
+    } else {
+        data = {
+            'cod_ciudad': $("#id_ciudad").val(),
+            'nombre_ciud': $("#nombre_ciud").val(),
+            'estado_ciud': $("#estado_ciud").val()
+        };
+        ejecutarAjax("controladores/ciudad.php", "actualizar=" + JSON.stringify(data));
+        mensaje_confirmacion("Actualizado Correctamente", "Actualizado");
+    }
+    mostrarListarCiudad();
 }
 //------------------------------------------------------------------------------
-//------------------------------------------------------------------------------
-//------------------------------------------------------------------------------
-function cargarTablaProveedores() {
-    let data = ejecutarAjax("controladores/proveedores.php", "leer=1");
-
-
+function cargarTablaCiudad() {
+    let data = ejecutarAjax("controladores/ciudad.php", "leer=1");
     let fila = "";
     if (data === "0") {
         fila = "NO HAY REGISTROS";
@@ -88,30 +50,20 @@ function cargarTablaProveedores() {
         let json_data = JSON.parse(data);
         json_data.map(function (item) {
             fila += `<tr>`;
-            fila += `<td>${item.cod_proveedor}</td>`;
-            fila += `<td>${item.nom_ape_prov}</td>`;
-            fila += `<td>${item.razon_social_prov}</td>`;
-            fila += `<td>${item.telefono_prov}</td>`;
-            fila += `<td>${item.ruc_prov}</td>`;
-            fila += `<td>${item.direccion_prov}</td>`;
-            fila += `<td>${item.email_prov}</td>`;
-            fila += `<td>${item.estado}</td>`;
             fila += `<td>${item.cod_ciudad}</td>`;
-            fila += `<td>
-                        <button class='btn btn-warning editar-proveedores'><i class='fa fa-edit'></i> Editar</button>
-                        <button class='btn btn-danger eliminar-proveedores'><i class='fa fa-trash'></i> Eliminar</button>
-                    </td>`;
+            fila += `<td>${item.nombre_ciud}</td>`;
+            fila += `<td>${item.estado_ciud}</td>`;
+            fila += `<td>`;
+            fila += `<button class='btn btn-warning editar-ciudad'><i class='fa fa-edit'></i> Editar</button>`;
+            fila += ` <button class='btn btn-danger eliminar-ciudad'><i class='fa fa-trash'></i> Eliminar</button>`;
+            fila += `</td>`;
             fila += `</tr>`;
         });
     }
-
-    $("#proveedores_tb").html(fila);
+    $("#ciudad_tb").html(fila);
 }
-
 //------------------------------------------------------------------------------
-//------------------------------------------------------------------------------
-//------------------------------------------------------------------------------
-$(document).on("click", ".editar-", function (evt) {
+$(document).on("click", ".editar-ciudad", function (evt) {
     let id = $(this).closest("tr").find("td:eq(0)").text();
     Swal.fire({
         title: "Atencion",
@@ -124,36 +76,21 @@ $(document).on("click", ".editar-", function (evt) {
         confirmButtonText: "Si"
     }).then((result) => {
         if (result.isConfirmed) {
-            let response = ejecutarAjax("controladores/proveedores.php", "id=" + id);
-            console.log(response);
-            if (response === "0") {
-
-            } else {
-                let json_data = JSON.parse(response);
-                //abrir ventana
-                let contenido = dameContenido("paginas/referenciales/insumo/agregar.php");
+            let response = ejecutarAjax("controladores/ciudad.php", "id=" + id);
+            if (response !== "0") {
+                let contenido = dameContenido("paginas/referenciales/ciudad/agregar.php");
                 $(".contenido-principal").html(contenido);
-
-    
-                //cargar los datos
                 let json_registro = JSON.parse(response);
-                $("#cod_proveedor").val(id);
-                $("#nom_ape_prov").val(json_registro['nom_ape_prov']);
-                $("#razon_social_prov").val(json_registro['razon_social_prov']);
-                $("#telefono_prov").val(json_registro['telefono_prov']);
-                $("#ruc_prov").val(json_registro['ruc_prov']);
-                $("#direccion_prov").val(json_registro['direccion_prov']);
-                $("#email_prov").val(json_registro['email_prov']);
-                $("#estado").val(json_registro['estado']);
-                $("#cod_ciudad").val(json_registro['cod_ciudad']);
+                $("#id_ciudad").val(json_registro['cod_ciudad']);
+                $("#cod").val(json_registro['cod_ciudad']);
+                $("#nombre_ciud").val(json_registro['nombre_ciud']);
+                $("#estado_ciud").val(json_registro['estado_ciud']);
             }
         }
     });
 });
 //------------------------------------------------------------------------------
-//------------------------------------------------------------------------------
-//------------------------------------------------------------------------------
-$(document).on("click", ".eliminar-", function (evt) {
+$(document).on("click", ".eliminar-ciudad", function (evt) {
     let id = $(this).closest("tr").find("td:eq(0)").text();
     Swal.fire({
         title: "Atencion",
@@ -166,65 +103,9 @@ $(document).on("click", ".eliminar-", function (evt) {
         confirmButtonText: "Si"
     }).then((result) => {
         if (result.isConfirmed) {
-            let response = ejecutarAjax("controladores/insumo.php",
-            "eliminar=" + id);
-
-            console.log(response);
+            ejecutarAjax("controladores/ciudad.php", "eliminar=" + id);
             mensaje_confirmacion("Eliminado Correctamente", "Eliminado");
-            mostrarListarProveedores();
+            cargarTablaCiudad();
         }
     });
 });
-//------------------------------------------------------------------------------
-//------------------------------------------------------------------------------
-//------------------------------------------------------------------------------
-$(document).on("keyup", "#b_insumo", function (evt) {
-    let data = ejecutarAjax("controladores/insumo.php", "leer_descripcion="+$("#b_insumo").val());
-
-
-    let fila = "";
-    if (data === "0") {
-        fila = "NO HAY REGISTROS";
-    } else {
-        let json_data = JSON.parse(data);
-        json_data.map(function (item) {
-            fila += `<tr>`;
-            fila += `<td>${item.cod_proveedor}</td>`;
-            fila += `<td>${item.nom_ape_prov}</td>`;
-            fila += `<td>${item.razon_social_prov}</td>`;
-            fila += `<td>${item.telefono_prov}</td>`;
-            fila += `<td>${item.ruc_prov}</td>`;
-            fila += `<td>${item.direccion_prov}</td>`;
-            fila += `<td>${item.email_prov}</td>`;
-            fila += `<td>${item.estado}</td>`;
-            fila += `<td>${item.cod_ciudad}</td>`;
-            fila += `<td>
-                        <button class='btn btn-warning editar-proveedores'><i class='fa fa-edit'></i> Editar</button>
-                        <button class='btn btn-danger eliminar-proveedores'><i class='fa fa-trash'></i> Eliminar</button>
-                    </td>`;
-            fila += `</tr>`;
-        });
-    }
-
-    $("#proveedores_tb").html(fila);
-});
-//-------------------------------------------------------------------------------
-//-------------------------------------------------------------------------------
-//-------------------------------------------------------------------------------
-function imprimirInsumo(){
-    window.open("paginas/referenciales/proveedores/print.php");
-}
-
-
-function cargarListaCiudad(componente) {
-    let datos = ejecutarAjax("controladores/ciudad.php", "leer_ciudad_activos=1");
-    console.log(datos);
-    let option = "<option value='0'>Selecciona una ciudad</option>";
-    if (datos !== "0") {
-        let json_datos = JSON.parse(datos);
-        json_datos.map(function (item) {
-            option += `<option value='${item.cod_ciudad}'>${item.descripcion_ciud}</option>`;
-        });
-    }
-    $(componente).html(option);
-}


### PR DESCRIPTION
## Summary
- add Ciudad to Referenciales menu and load its scripts
- implement full CRUD for Ciudad with dedicated controller, pages and JS

## Testing
- `php -l controladores/ciudad.php`
- `php -l main.php`
- `php -l paginas/referenciales/ciudad/listar.php`
- `php -l paginas/referenciales/ciudad/agregar.php`


------
https://chatgpt.com/codex/tasks/task_e_688fa2dc82348333a69027ae62a69416