### PR TITLE
feat: update order purchase to use products

### DIFF
--- a/compu_click.sql
+++ b/compu_click.sql
@@ -682,7 +682,7 @@ INSERT INTO `det_nota_remision` (`cod_remision`, `cod_insumos`, `cantidad`, `can
 
 CREATE TABLE `det_orden` (
   `cod_orden` int(11) NOT NULL,
-  `cod_insumos` int(11) NOT NULL,
+  `cod_producto` int(11) NOT NULL,
   `cantidad` int(11) NOT NULL,
   `prec_uni` int(11) NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
@@ -691,7 +691,7 @@ CREATE TABLE `det_orden` (
 -- Volcado de datos para la tabla `det_orden`
 --
 
-INSERT INTO `det_orden` (`cod_orden`, `cod_insumos`, `cantidad`, `prec_uni`) VALUES
+INSERT INTO `det_orden` (`cod_orden`, `cod_producto`, `cantidad`, `prec_uni`) VALUES
 (1, 1, 7, 450000),
 (1, 2, 8, 120000),
 (2, 1, 1, 65000),
@@ -1882,8 +1882,8 @@ ALTER TABLE `det_nota_remision`
 -- Indices de la tabla `det_orden`
 --
 ALTER TABLE `det_orden`
-  ADD PRIMARY KEY (`cod_orden`,`cod_insumos`),
-  ADD KEY `insumos_det_orden_fk` (`cod_insumos`);
+  ADD PRIMARY KEY (`cod_orden`,`cod_producto`),
+  ADD KEY `producto_det_orden_fk` (`cod_producto`);
 
 --
 -- Indices de la tabla `det_pedido_compra`
@@ -2335,7 +2335,7 @@ ALTER TABLE `det_nota_compra`
 -- Filtros para la tabla `det_orden`
 --
 ALTER TABLE `det_orden`
-  ADD CONSTRAINT `insumos_det_orden_fk` FOREIGN KEY (`cod_insumos`) REFERENCES `insumos` (`cod_insumos`) ON DELETE NO ACTION ON UPDATE NO ACTION,
+  ADD CONSTRAINT `producto_det_orden_fk` FOREIGN KEY (`cod_producto`) REFERENCES `producto` (`cod_producto`) ON DELETE NO ACTION ON UPDATE NO ACTION,
   ADD CONSTRAINT `orden_compra_det_orden_fk` FOREIGN KEY (`cod_orden`) REFERENCES `orden_compra` (`cod_orden`) ON DELETE NO ACTION ON UPDATE NO ACTION;
 
 --

--- a/controladores/orden_compra_detalle.php
+++ b/controladores/orden_compra_detalle.php
@@ -12,8 +12,8 @@ function guardar($lista) {
     $json_datos = json_decode($lista, true);
     $base_datos = new DB();
     $query = $base_datos->conectar()->prepare("INSERT INTO det_orden
-(cod_orden, cod_insumos, cantidad, prec_uni)
-VALUES(:cod_orden_compra, :cod_material, :cantidad, :costo);");
+(cod_orden, cod_producto, cantidad, prec_uni)
+VALUES(:cod_orden_compra, :cod_producto, :cantidad, :costo);");
 
     $query->execute($json_datos);
 }
@@ -103,17 +103,14 @@ VALUES(:cod_orden_compra, :cod_material, :cantidad, :costo);");
  function id($id){
      $base_datos = new DB();
      $query = $base_datos->conectar()->prepare("select 
-        m.cod_insumos as cod_material,
-        m.descripcion  as nombre_material,
+        p.cod_producto as cod_producto,
+        p.nombre  as nombre_producto,
         dpc.cantidad ,
         dpc.prec_uni as costo,
-        dpc.cantidad  * dpc.prec_uni  as total,
-        IF(m.cod_impuesto = 1, dpc.prec_uni * dpc.cantidad, 0) as iva10,
-        IF(m.cod_impuesto = 2, dpc.prec_uni * dpc.cantidad, 0) as iva5,
-         IF(m.cod_impuesto = 3, dpc.prec_uni * dpc.cantidad, 0) as exenta
-        from det_orden  dpc 
-        join insumos m ON m.cod_insumos  = dpc.cod_insumos 
-         WHERE dpc.cod_orden  = $id ");
+        dpc.cantidad  * dpc.prec_uni  as total
+        from det_orden  dpc
+        join producto p ON p.cod_producto  = dpc.cod_producto
+        WHERE dpc.cod_orden  = $id ");
     
      $query->execute();
 

--- a/paginas/movimientos/compra/orden_compra/agregar.php
+++ b/paginas/movimientos/compra/orden_compra/agregar.php
@@ -38,16 +38,16 @@
         <hr> 
     </div>
     <div class="col-md-4">
-        <label>Insumo</label>
-        <select name="" id="insumo_lst" class="form-control"></select>
+        <label>Producto</label>
+        <select name="" id="producto_lst" class="form-control"></select>
     </div>
     <div class="col-md-3">
         <label>Cantidad</label>
         <input type="text" value="1" class="form-control formatear-numero" id="cantidad_txt">
     </div>
     <div class="col-md-3">
-        <label>Costo</label>
-        <input type="text" value="1" class="form-control formatear-numero" id="costo_txt">
+        <label>Precio</label>
+        <input type="text" value="1" class="form-control formatear-numero" id="precio_txt">
     </div>
     <div class="col-md-2">
         <label>Operaciones</label>
@@ -63,11 +63,11 @@
             <thead>
                 <tr>
                      <th>#</th>
-                     <th>Insumo</th>
-                     <th>Costo</th>
+                     <th>Producto</th>
+                     <th>Precio</th>
                      <th>Cantidad</th>
                      <th>Total</th>
-                    
+
                 </tr>
             </thead>
             <tbody id="orden_compra_compra"></tbody>

--- a/paginas/movimientos/compra/orden_compra/print.php
+++ b/paginas/movimientos/compra/orden_compra/print.php
@@ -21,13 +21,13 @@ join det_orden  dp
 on dp.cod_orden  = pc.cod_orden 
 where pc.cod_orden =  :id");
 
-$detalle = $base_datos->conectar()->prepare("select 
- m.descripcion  as nombre_imsumo,
+$detalle = $base_datos->conectar()->prepare("select
+ p.nombre  as nombre_producto,
  dpc.cantidad ,
  dpc.prec_uni as costo,
  dpc.cantidad  * dpc.prec_uni  as total
- from det_orden  dpc 
- join insumos m ON m.cod_insumos  = dpc.cod_insumos  
+ from det_orden  dpc
+ join producto p ON p.cod_producto  = dpc.cod_producto
  where dpc.cod_orden =:id");
 
 $query->bindParam(':id', $_GET['id'], PDO::PARAM_INT);
@@ -126,7 +126,7 @@ $arreglo = $query->fetch(PDO::FETCH_OBJ);
                         <tr>
                             <th>Descripcion</th>
                             <th>Cantidad</th>
-                            <th>Costo</th>
+                            <th>Precio</th>
                             <th>Total</th>
                         </tr>
                     </thead>
@@ -138,7 +138,7 @@ $arreglo = $query->fetch(PDO::FETCH_OBJ);
                                 
                                 ?>
                                 <tr>
-                                    <td><?= $fila['nombre_imsumo'] ?></td>
+                                    <td><?= $fila['nombre_producto'] ?></td>
                                     <td><?= number_format($fila['cantidad'], 0, ',', '.') ?></td>
                                     <td><?= number_format($fila['costo'], 0, ',', '.') ?></td>
                                     <td><?= number_format($fila['total'], 0, ',', '.') ?></td>

--- a/vista/orden_compra.js
+++ b/vista/orden_compra.js
@@ -5,6 +5,18 @@ function mostrarListarOrdenCompra() {
 }
 //------------------------------------------------------------------------------
 //------------------------------------------------------------------------------
+function cargarListaProducto(componente) {
+    let datos = ejecutarAjax("controladores/proyecto.php", "leer=1");
+    let option = "<option value='0'>Selecciona un Producto</option>";
+    if (datos !== "0") {
+        let json_datos = JSON.parse(datos);
+        json_datos.map(function (item) {
+            option += `<option value='${item.cod_producto}'>${item.nombre}</option>`;
+        });
+    }
+    $(componente).html(option);
+}
+
 //------------------------------------------------------------------------------
 function mostrarAgregarOrdenCompra() {
     let contenido = dameContenido("paginas/movimientos/compra/orden_compra/agregar.php");
@@ -20,7 +32,7 @@ function mostrarAgregarOrdenCompra() {
 
 
     }
-    cargarListaInsumo("#insumo_lst");
+    cargarListaProducto("#producto_lst");
     cargarListaProveedorActivos("#proveedor_compra_lst");
     cargarListaPresupuestoPendientes("#presupuesto_compra_lst");
 
@@ -49,8 +61,8 @@ function cancelarOrdenCompra() {
 //------------------------------------------------------------------------------
 //------------------------------------------------------------------------------
 function agregarTablaOrdenCompra() {
-    if ($("#insumo_lst").val() === "0") {
-        mensaje_dialogo_info_ERROR("Debes seleccionar un material", "ATENCION");
+    if ($("#producto_lst").val() === "0") {
+        mensaje_dialogo_info_ERROR("Debes seleccionar un producto", "ATENCION");
         return;
     }
 
@@ -65,15 +77,15 @@ function agregarTablaOrdenCompra() {
         mensaje_dialogo_info_ERROR("La cantidad debe ser mayor a cero", "ATENCION");
         return;
     }
-    if ($("#costo_txt").val().trim().length === 0) {
-        mensaje_dialogo_info_ERROR("Debes ingresar un costo", "ATENCION");
+    if ($("#precio_txt").val().trim().length === 0) {
+        mensaje_dialogo_info_ERROR("Debes ingresar un precio", "ATENCION");
         return;
     }
 
-    let costo = quitarDecimalesConvertir($("#costo_txt").val().trim());
+    let precio = quitarDecimalesConvertir($("#precio_txt").val().trim());
 
-    if (costo <= 0) {
-        mensaje_dialogo_info_ERROR("El costo debe ser mayor a cero", "ATENCION");
+    if (precio <= 0) {
+        mensaje_dialogo_info_ERROR("El precio debe ser mayor a cero", "ATENCION");
         return;
     }
 
@@ -82,8 +94,8 @@ function agregarTablaOrdenCompra() {
     $("#orden_compra_compra tr").each(function () {
 
 
-        if ($(this).find("td:eq(0)").text() === $("#insumo_lst").val()) {
-            mensaje_dialogo_info_ERROR("El insumo ya ha sido agregado anteriormente", "ATENCION");
+        if ($(this).find("td:eq(0)").text() === $("#producto_lst").val()) {
+            mensaje_dialogo_info_ERROR("El producto ya ha sido agregado anteriormente", "ATENCION");
             materialRepetido = true; // Marca como repetido
             return false; // Rompe el ciclo
         }
@@ -93,11 +105,11 @@ function agregarTablaOrdenCompra() {
     if (!materialRepetido) {
         $("#orden_compra_compra").append(`
         <tr>
-            <td>${$("#insumo_lst").val()}</td>
-            <td>${$("#insumo_lst option:selected").html().split(" | ")[0]}</td>
-            <td><input class="form-control costo-presu" value="${formatearNumero($("#costo_txt").val())}"></td>
+            <td>${$("#producto_lst").val()}</td>
+            <td>${$("#producto_lst option:selected").html().split(" | ")[0]}</td>
+            <td><input class="form-control costo-presu" value="${formatearNumero($("#precio_txt").val())}"></td>
             <td>${$("#cantidad_txt").val()}</td>
-            <td>${formatearNumero(cantidad * costo)}</td>
+            <td>${formatearNumero(cantidad * precio)}</td>
             <td>
                 <button class="btn btn-danger remover-item-orden_compra">Remover</button>
             </td>
@@ -172,7 +184,7 @@ function guardarOrdenCompra() {
     $("#orden_compra_compra tr").each(function (evt) {
         let detalle = {
             'cod_orden_compra': $("#cod").val(),
-            'cod_material': $(this).find("td:eq(0)").text(),
+            'cod_producto': $(this).find("td:eq(0)").text(),
             'costo': quitarDecimalesConvertir($(this).find("input").val()),
             'cantidad': $(this).find("td:eq(3)").text()
         };
@@ -219,6 +231,21 @@ function cargarTablaOrdenCompra() {
 function imprimirOrdenCompra(id) {
     window.open("paginas/movimientos/compra/orden_compra/print.php?id=" + id);
 }
+//----------------------------------------------------------------------------
+//----------------------------------------------------------------------------
+//----------------------------------------------------------------------------
+$(document).on("change", "#producto_lst", function (evt) {
+    if ($("#producto_lst").val() === "0") {
+        $("#precio_txt").val("1");
+    } else {
+        let producto = ejecutarAjax("controladores/proyecto.php", "id=" + $("#producto_lst").val());
+        if (producto !== "0") {
+            let json_producto = JSON.parse(producto);
+            $("#precio_txt").val(formatearNumero(json_producto['precio']));
+        }
+    }
+});
+
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- switch order purchase form to select products and auto-fill price
- register product details in purchase order controller and print
- adjust database schema for product-based order details

## Testing
- `php -l paginas/movimientos/compra/orden_compra/agregar.php`
- `php -l paginas/movimientos/compra/orden_compra/print.php`
- `php -l controladores/orden_compra_detalle.php`
- `node --check vista/orden_compra.js`


------
https://chatgpt.com/codex/tasks/task_e_688fada9f53c833389784d8df9526196