### PR TITLE
Cambiar insumo por producto en factura de compra

### DIFF
--- a/controladores/factura_compra_detalle.php
+++ b/controladores/factura_compra_detalle.php
@@ -13,7 +13,7 @@ function guardar($lista) {
     $base_datos = new DB();
     $query = $base_datos->conectar()->prepare("INSERT INTO detalle_compra
         (cod_compra, cod_insumos, cantidad, costo)
-     VALUES (:cod_compra,:cod_material,:cantidad,:costo)");
+     VALUES (:cod_compra,:cod_producto,:cantidad,:costo)");
 
     $query->execute($json_datos);
 }
@@ -101,9 +101,9 @@ function guardar($lista) {
 
  function id($id){
      $base_datos = new DB();
-     $query = $base_datos->conectar()->prepare("select 
- m.cod_insumos  as cod_material,
- m.descripcion  as nombre_insumo,
+    $query = $base_datos->conectar()->prepare("select
+ m.cod_insumos  as cod_producto,
+ m.descripcion  as nombre_producto,
  dpc.cantidad ,
  dpc.costo as costo,
  dpc.cantidad  * dpc.costo  as total,

--- a/controladores/nota_compra_det.php
+++ b/controladores/nota_compra_det.php
@@ -13,7 +13,7 @@ function guardar($lista) {
     $base_datos = new DB();
     $query = $base_datos->conectar()->prepare("INSERT INTO deta_nota
 (cod_nota, cod_insumo, cantidad, costo)
-VALUES(:cod_nota_compra, :cod_material,  :cantidad, :costo);");
+VALUES(:cod_nota_compra, :cod_producto,  :cantidad, :costo);");
 
     $query->execute($json_datos);
     

--- a/controladores/remision_detalle.php
+++ b/controladores/remision_detalle.php
@@ -12,7 +12,7 @@ function guardar($lista) {
     $base_datos = new DB();
     $query = $base_datos->conectar()->prepare("INSERT INTO det_nota_remision
 (cod_remision, cod_insumos, cantidad, cantidad_factura)
-VALUES(:cod_nota_remision, :cod_material, :cantidad,  :cantidad_factura);");
+VALUES(:cod_nota_remision, :cod_producto, :cantidad,  :cantidad_factura);");
 
     $query->execute($json_datos);
     

--- a/paginas/movimientos/compra/factura_compra/agregar.php
+++ b/paginas/movimientos/compra/factura_compra/agregar.php
@@ -72,8 +72,8 @@
         <hr> 
     </div>
     <div class="col-md-4">
-        <label>Insumo</label>
-        <select name="" id="material_lst" class="form-control"></select>
+        <label>Producto</label>
+        <select name="" id="producto_lst" class="form-control"></select>
     </div>
     <div class="col-md-3">
         <label>Cantidad</label>
@@ -97,7 +97,7 @@
             <thead>
                 <tr>
                      <th>#</th>
-                     <th>Insumo</th>
+                    <th>Producto</th>
                      <th>Costo</th>
                      <th>Cantidad</th>
                      <th>Exento</th>

--- a/vista/factura_compra.js
+++ b/vista/factura_compra.js
@@ -10,7 +10,7 @@ function mostrarAgregarFacturaCompra() {
     let contenido = dameContenido("paginas/movimientos/compra/factura_compra/agregar.php");
     $(".contenido-principal").html(contenido);
    
-    cargarListaInsumo("#material_lst");
+    cargarListaProducto("#producto_lst");
     dameFechaActual("fecha");
     dameFechaActual("fecha_venc");
     cargarListaOrdenPendiente("#orden_compra_lst");
@@ -51,8 +51,8 @@ function cancelarFacturaCompra() {
 //------------------------------------------------------------------------------
 //------------------------------------------------------------------------------
 function agregarTablaFacturaCompra() {
-    if ($("#material_lst").val() === "0") {
-        mensaje_dialogo_info_ERROR("Debes seleccionar un material", "ATENCION");
+    if ($("#producto_lst").val() === "0") {
+        mensaje_dialogo_info_ERROR("Debes seleccionar un producto", "ATENCION");
         return;
     }
 
@@ -79,28 +79,28 @@ function agregarTablaFacturaCompra() {
         return;
     }
 
-    let materialRepetido = false; // Variable para detectar si el material ya existe
+    let productoRepetido = false; // Variable para detectar si el producto ya existe
 
     $("#factura_compra tr").each(function (evt) {
 
 
-        if ($(this).find("td:eq(0)").text() === $("#material_lst").val()) {
-            mensaje_dialogo_info_ERROR("El material ya ha sido agregado anteriormente", "ATENCION");
-            materialRepetido = true; // Marca como repetido
+        if ($(this).find("td:eq(0)").text() === $("#producto_lst").val()) {
+            mensaje_dialogo_info_ERROR("El producto ya ha sido agregado anteriormente", "ATENCION");
+            productoRepetido = true; // Marca como repetido
             return false; // Rompe el ciclo
         }
     });
-    
-    let producto  = ejecutarAjax("controladores/insumo.php", "id="+$("#material_lst").val());
+
+    let producto  = ejecutarAjax("controladores/insumo.php", "id="+$("#producto_lst").val());
     
     let json_producto = JSON.parse(producto);
 
-// Si no se encontró material repetido, agrega una nueva fila
-    if (!materialRepetido) {
+// Si no se encontró producto repetido, agrega una nueva fila
+    if (!productoRepetido) {
         $("#factura_compra").append(`
         <tr>
-            <td>${$("#material_lst").val()}</td>
-            <td>${$("#material_lst option:selected").html()}</td>
+            <td>${$("#producto_lst").val()}</td>
+            <td>${$("#producto_lst option:selected").html()}</td>
             <td>${formatearNumero($("#costo_txt").val())}</td>
             <td>${$("#cantidad_txt").val()}</td>
             <td>${(json_producto['cod_impuesto'] === 3) ? formatearNumero(cantidad * costo) : 0} </td>
@@ -232,7 +232,7 @@ function guardarFacturaCompra() {
     $("#factura_compra tr").each(function (evt) {
         let detalle = {
             'cod_compra': $("#cod").val(),
-            'cod_material': $(this).find("td:eq(0)").text(),
+            'cod_producto': $(this).find("td:eq(0)").text(),
             'costo': quitarDecimalesConvertir($(this).find("td:eq(2)").text()),
             'cantidad': $(this).find("td:eq(3)").text()
         };

--- a/vista/insumo.js
+++ b/vista/insumo.js
@@ -11,6 +11,23 @@ function cargarListaInsumo(componente) {
     $(componente).html(option);
 }
 
+// Alias de \"cargarListaInsumo\" que muestra la lista como Productos
+// Se reutiliza el mismo controlador y datos, pero se cambia el texto
+// mostrado al usuario para mantener compatibilidad con otras partes del
+// sistema que aún utilizan la denominación \"insumo\".
+function cargarListaProducto(componente) {
+    let datos = ejecutarAjax("controladores/insumo.php", "leer_activos=1");
+    console.log(datos);
+    let option = "<option value='0'>Selecciona un Producto</option>";
+    if (datos !== "0") {
+        let json_datos = JSON.parse(datos);
+        json_datos.map(function (item) {
+            option += `<option value='${item.cod_insumos}'>${item.descripcion}</option>`;
+        });
+    }
+    $(componente).html(option);
+}
+
 function mostrarListarInsumo() {
     let contenido = dameContenido("paginas/referenciales/insumo/listar.php");
     $(".contenido-principal").html(contenido);

--- a/vista/nota_credito_compra.js
+++ b/vista/nota_credito_compra.js
@@ -221,7 +221,7 @@ function guardarNotaCreditoCompra() {
              
             let detalle = {
                 'cod_nota_compra': $("#cod").val(),
-                'cod_material': $(this).find("td:eq(0)").text(),
+                'cod_producto': $(this).find("td:eq(0)").text(),
                 'costo': quitarDecimalesConvertir($(this).find("td:eq(2)").text()),
                 'cantidad': $(this).find("input:eq(0)").val()
             };
@@ -301,8 +301,8 @@ $(document).on("change", "#facturas_compra_lst", function (evt) {
             json_data.map(function (item) {
                 $("#nota_compra").append(`
                     <tr>
-                        <td>${item.cod_material}</td>
-                        <td>${item.nombre_insumo}</td>
+                        <td>${item.cod_producto}</td>
+                        <td>${item.nombre_producto}</td>
                         <td>${formatearNumero(item.costo)}</td>
                         <td><input type='number' max="${item.cantidad}" class="cantidad-nota form-control" value='${item.cantidad}' min="1"></td>
                         <td>${formatearNumero(item.exenta)}</td>

--- a/vista/remision.js
+++ b/vista/remision.js
@@ -192,7 +192,7 @@ function guardarRemision(){
     $("#ajuste_stock_compra tr").each(function(evt) {
         let detalle = {
             'cod_nota_remision' : $("#cod").val(),
-            'cod_material' : $(this).find("td:eq(0)").text(),
+            'cod_producto' : $(this).find("td:eq(0)").text(),
             'cantidad_factura' : $(this).find("td:eq(2)").text(),
             'cantidad' : $(this).find("input").val()
         };
@@ -269,7 +269,7 @@ $(document).on("click", ".anular-remision", function (evt) {
 //$("#material_lst").change(function () {
 //    let codMaterial = $(this).val();
 //    if (codMaterial) {
-//        let data = ejecutarAjax("controladores/remision.php", "cod_material=" + codMaterial);
+//        let data = ejecutarAjax("controladores/remision.php", "cod_producto=" + codMaterial);
 //        let materialInfo = JSON.parse(data);
 //        $("#tipo_material").val(materialInfo.tipo_material); // Cargar tipo de material
 //    }
@@ -321,8 +321,8 @@ $(document).on("change", "#factura_compra_remision_lst", function (evt) {
             json_data.map(function (item) {
                 $("#ajuste_stock_compra").append(`
                     <tr>
-                        <td>${item.cod_material}</td>
-                        <td>${item.nombre_insumo}</td>
+                        <td>${item.cod_producto}</td>
+                        <td>${item.nombre_producto}</td>
                         <td>${item.cantidad}</td>
                         <td><input type='number' value='${item.cantidad}' class='form-control'></td>
                     </tr>


### PR DESCRIPTION
## Summary
- Reemplazado el uso de "insumo" por "producto" en la interfaz de Factura de Compra, ajustando formularios, mensajes y guardado de detalles con `cod_producto`.
- Agregado `cargarListaProducto` reutilizando el controlador existente para presentar los artículos como productos.
- Actualizados controladores y vistas relacionadas (detalle de factura, notas de crédito y remisiones) para registrar y mostrar productos en la base de datos.

## Testing
- `php -l controladores/factura_compra_detalle.php`
- `php -l controladores/nota_compra_det.php`
- `php -l controladores/remision_detalle.php`
- `node --check vista/insumo.js`
- `node --check vista/factura_compra.js`
- `node --check vista/nota_credito_compra.js`
- `node --check vista/remision.js`


------
https://chatgpt.com/codex/tasks/task_e_688fae53b8688333b121f80aabd68ed4