### PR TITLE
feat: add IVA type to products

### DIFF
--- a/compu_click.sql
+++ b/compu_click.sql
@@ -907,7 +907,7 @@ INSERT INTO `funcionario` (`cod_funcionario`, `nombre_funcionario`, `ci_funciona
 --
 
 CREATE TABLE `impuesto` (
-  `cod_impuesto` int(11) NOT NULL,
+  `tipo_iva` int(11) NOT NULL,
   `descripcion` varchar(50) COLLATE utf8_unicode_ci DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
@@ -930,7 +930,7 @@ CREATE TABLE `insumos` (
   `cod_insumos` int(11) NOT NULL,
   `descripcion` varchar(100) COLLATE utf8_unicode_ci DEFAULT NULL,
   `cod_marca_insumos` int(11) NOT NULL,
-  `cod_impuesto` int(11) NOT NULL,
+  `tipo_iva` int(11) NOT NULL,
   `cantidad` int(11) DEFAULT NULL,
   `estado_insumos` varchar(50) COLLATE utf8_unicode_ci DEFAULT NULL,
   `costo` int(11) DEFAULT NULL,
@@ -941,11 +941,11 @@ CREATE TABLE `insumos` (
 -- Volcado de datos para la tabla `insumos`
 --
 
-INSERT INTO `insumos` (`cod_insumos`, `descripcion`, `cod_marca_insumos`, `cod_impuesto`, `cantidad`, `estado_insumos`, `costo`, `precio`) VALUES
-(1, 'INSUMO 1', 1, 1, 100, 'ACTIVO', 33000, 150000),
-(2, 'INSUMO 2', 1, 2, 1, 'ACTIVO', 43000, 178000),
-(3, 'INSUMO 3', 1, 2, 0, 'ACTIVO', 13000, 138000),
-(4, 'INSUMO 7', 1, 1, 11, 'ACTIVO', 120000, 790000);
+INSERT INTO `insumos` (`cod_insumos`, `descripcion`, `cod_marca_insumos`, `tipo_iva`, `cantidad`, `estado_insumos`, `costo`, `precio`) VALUES
+(1, 'INSUMO 1', 1, 10, 100, 'ACTIVO', 33000, 150000),
+(2, 'INSUMO 2', 1, 5, 1, 'ACTIVO', 43000, 178000),
+(3, 'INSUMO 3', 1, 5, 0, 'ACTIVO', 13000, 138000),
+(4, 'INSUMO 7', 1, 10, 11, 'ACTIVO', 120000, 790000);
 
 -- --------------------------------------------------------
 
@@ -1978,8 +1978,7 @@ ALTER TABLE `impuesto`
 --
 ALTER TABLE `insumos`
   ADD PRIMARY KEY (`cod_insumos`),
-  ADD KEY `marca_insumos_insumos_fk` (`cod_marca_insumos`),
-  ADD KEY `impuesto_insumos_fk` (`cod_impuesto`);
+  ADD KEY `marca_insumos_insumos_fk` (`cod_marca_insumos`);
 
 --
 -- Indices de la tabla `libro_compras`
@@ -2396,7 +2395,6 @@ ALTER TABLE `funcionario`
 -- Filtros para la tabla `insumos`
 --
 ALTER TABLE `insumos`
-  ADD CONSTRAINT `impuesto_insumos_fk` FOREIGN KEY (`cod_impuesto`) REFERENCES `impuesto` (`cod_impuesto`) ON DELETE NO ACTION ON UPDATE NO ACTION,
   ADD CONSTRAINT `marca_insumos_insumos_fk` FOREIGN KEY (`cod_marca_insumos`) REFERENCES `marca_insumos` (`cod_marca_insumos`) ON DELETE NO ACTION ON UPDATE NO ACTION;
 
 --

--- a/controladores/factura_compra_detalle.php
+++ b/controladores/factura_compra_detalle.php
@@ -107,10 +107,10 @@ function guardar($lista) {
  dpc.cantidad ,
  dpc.costo as costo,
  dpc.cantidad  * dpc.costo  as total,
- m.cod_impuesto,
- IF(m.cod_impuesto = 1, dpc.costo * dpc.cantidad, 0) as iva10,
- IF(m.cod_impuesto = 2, dpc.costo * dpc.cantidad, 0) as iva5,
-  IF(m.cod_impuesto = 3, dpc.costo  * dpc.cantidad, 0) as exenta
+ m.tipo_iva,
+ IF(m.tipo_iva = 10, dpc.costo * dpc.cantidad, 0) as iva10,
+ IF(m.tipo_iva = 5, dpc.costo * dpc.cantidad, 0) as iva5,
+ IF(m.tipo_iva = 0, dpc.costo  * dpc.cantidad, 0) as exenta
  from detalle_compra   dpc 
  join insumos m ON m.cod_insumos  = dpc.cod_insumos  
  where dpc.cod_compra =  $id ");

--- a/controladores/insumo.php
+++ b/controladores/insumo.php
@@ -33,9 +33,9 @@ function guardar($lista) {
     $json_datos = json_decode($lista, true);
     $base_datos = new DB();
     $query = $base_datos->conectar()->prepare("INSERT INTO `insumos`(`cod_insumos`, "
-            . "`descripcion`, `cod_marca_insumos`, `cod_impuesto`, `cantidad`, "
+            . "`descripcion`, `cod_marca_insumos`, `tipo_iva`, `cantidad`, "
             . "`estado_insumos`, `costo`, `precio`) VALUES (:cod_insumos,"
-            . ":descripcion,:cod_marca_insumos,:cod_impuesto,:cantidad,:estado_insumos,"
+            . ":descripcion,:cod_marca_insumos,:tipo_iva,:cantidad,:estado_insumos,"
             . ":costo,:precio)");
 
     $query->execute($json_datos);
@@ -51,13 +51,11 @@ if(isset($_POST['leer'])){
 
 function leer(){
     $base_datos = new DB();
-    $query = $base_datos->conectar()->prepare("SELECT i.`cod_insumos`, 
-        i.`descripcion`, mi.descripcion_marca, im.descripcion as des_imp, 
+    $query = $base_datos->conectar()->prepare("SELECT i.`cod_insumos`,
+        i.`descripcion`, mi.descripcion_marca, i.`tipo_iva`,
         i.`cantidad`, i.`estado_insumos`, i.`costo`, i.`precio` FROM insumos i
 JOIN marca_insumos mi
-ON i.cod_marca_insumos = mi.cod_marca_insumos
-JOIN impuesto im
-ON im.cod_impuesto = i.cod_impuesto");
+ON i.cod_marca_insumos = mi.cod_marca_insumos");
     
     $query->execute();
 
@@ -77,7 +75,7 @@ if(isset($_POST['id'])){
 function id($id){
     $base_datos = new DB();
     $query = $base_datos->conectar()->prepare("SELECT `cod_insumos`, "
-            . "`descripcion`, `cod_marca_insumos`, `cod_impuesto`, "
+            . "`descripcion`, `cod_marca_insumos`, `tipo_iva`, "
             . "`cantidad`, `estado_insumos`, `costo`, `precio` "
             . "FROM `insumos` WHERE `cod_insumos` = $id ");
     
@@ -102,7 +100,7 @@ function actualizar($lista){
     $base_datos = new DB();
     $query = $base_datos->conectar()->prepare("UPDATE `insumos` SET "
             . "`descripcion`=:descripcion,`cod_marca_insumos`=:cod_marca_insumos,"
-            . "`cod_impuesto`=:cod_impuesto,`cantidad`=:cantidad,"
+            . "`tipo_iva`=:tipo_iva,`cantidad`=:cantidad,"
             . "`estado_insumos`=:estado_insumos,`costo`=:costo,"
             . "`precio`=:precio WHERE `cod_insumos`=:cod_insumos");
 
@@ -164,7 +162,7 @@ function leer_ciudad_activos() {
     $base_datos = new DB();
 
     $query = $base_datos->conectar()->prepare("SELECT `cod_insumos`, 
-        `descripcion`, `cod_marca_insumos`, `cod_impuesto`, `cantidad`, 
+        `descripcion`, `cod_marca_insumos`, `tipo_iva`, `cantidad`, 
         `estado_insumos`, `costo`, `precio` FROM `insumos` WHERE estado_insumos = 
         'ACTIVO'
 ");
@@ -211,17 +209,10 @@ function leer_activos_marca() {
 }
 
 function leer_activos_impuesto() {
-//    $json_datos = json_decode($lista, true);
-    $base_datos = new DB();
-
-    $query = $base_datos->conectar()->prepare("SELECT `cod_impuesto`, `descripcion` FROM `impuesto`
-");
-
-    $query->execute();
-
-    if ($query->rowCount()) {
-        print_r(json_encode($query->fetchAll(PDO::FETCH_OBJ)));
-    } else {
-        echo '0';
-    }
+    $lista = [
+        ['tipo_iva' => 0, 'descripcion' => 'EXENTO'],
+        ['tipo_iva' => 5, 'descripcion' => 'I.V.A. 5%'],
+        ['tipo_iva' => 10, 'descripcion' => 'I.V.A. 10%']
+    ];
+    print_r(json_encode($lista));
 }

--- a/paginas/movimientos/compra/factura_compra/print.php
+++ b/paginas/movimientos/compra/factura_compra/print.php
@@ -31,9 +31,9 @@ $detalle = $base_datos->conectar()->prepare(" select
  dpc.cantidad ,
  dpc.costo as costo,
  dpc.cantidad  * dpc.costo  as total,
- IF(m.cod_impuesto = 1, dpc.costo * dpc.cantidad, 0) as iva10,
- IF(m.cod_impuesto = 2, dpc.costo * dpc.cantidad, 0) as iva5,
-  IF(m.cod_impuesto = 3, dpc.costo  * dpc.cantidad, 0) as exenta
+ IF(m.tipo_iva = 10, dpc.costo * dpc.cantidad, 0) as iva10,
+ IF(m.tipo_iva = 5, dpc.costo * dpc.cantidad, 0) as iva5,
+ IF(m.tipo_iva = 0, dpc.costo  * dpc.cantidad, 0) as exenta
  from detalle_compra   dpc 
  join insumos m ON m.cod_insumos  = dpc.cod_insumos  
  where dpc.cod_compra =  :id");

--- a/paginas/movimientos/compra/nota_credito/print.php
+++ b/paginas/movimientos/compra/nota_credito/print.php
@@ -25,9 +25,9 @@ $detalle = $base_datos->conectar()->prepare(" select
  m.descripcion  as nombre_material,
  dpc.cantidad ,
  dpc.costo ,
- IF(m.cod_impuesto = 1, dpc.costo * dpc.cantidad, 0) as iva10,
- IF(m.cod_impuesto = 2, dpc.costo * dpc.cantidad, 0) as iva5,
-  IF(m.cod_impuesto = 3, dpc.costo  * dpc.cantidad, 0) as exenta
+ IF(m.tipo_iva = 10, dpc.costo * dpc.cantidad, 0) as iva10,
+ IF(m.tipo_iva = 5, dpc.costo * dpc.cantidad, 0) as iva5,
+ IF(m.tipo_iva = 0, dpc.costo  * dpc.cantidad, 0) as exenta
  from deta_nota   dpc 
  join insumos m ON m.cod_insumos  = dpc.cod_insumo
  where dpc.cod_nota  =  :id");

--- a/paginas/referenciales/insumo/agregar.php
+++ b/paginas/referenciales/insumo/agregar.php
@@ -25,8 +25,8 @@
             </select>
         </div>
         <div class="col-md-6">
-            <label for="">Impuesto</label>
-            <select id="impuesto_insumo" class="form-control">
+            <label for="">Tipo IVA</label>
+            <select id="tipo_iva_insumo" class="form-control">
             </select>
         </div>
         <div class="col-md-6">

--- a/paginas/referenciales/insumo/listar.php
+++ b/paginas/referenciales/insumo/listar.php
@@ -21,7 +21,7 @@
                    <th>#</th>
                     <th>Descripcion</th>
                     <th>Marca</th>
-                    <th>Impuesto</th>
+                    <th>Tipo IVA</th>
                     <th>Precio</th>  
                     <th>Estado</th>
                     <th>Operaciones</th>

--- a/vista/factura_compra.js
+++ b/vista/factura_compra.js
@@ -92,7 +92,7 @@ function agregarTablaFacturaCompra() {
     });
 
     let producto  = ejecutarAjax("controladores/insumo.php", "id="+$("#producto_lst").val());
-    
+
     let json_producto = JSON.parse(producto);
 
 // Si no se encontró producto repetido, agrega una nueva fila
@@ -103,9 +103,9 @@ function agregarTablaFacturaCompra() {
             <td>${$("#producto_lst option:selected").html()}</td>
             <td>${formatearNumero($("#costo_txt").val())}</td>
             <td>${$("#cantidad_txt").val()}</td>
-            <td>${(json_producto['cod_impuesto'] === 3) ? formatearNumero(cantidad * costo) : 0} </td>
-            <td>${(json_producto['cod_impuesto'] === 2) ? formatearNumero(cantidad * costo) : 0} </td>
-            <td>${(json_producto['cod_impuesto'] === 1) ? formatearNumero(cantidad * costo) : 0} </td>
+            <td>${(json_producto['tipo_iva'] == 0) ? formatearNumero(cantidad * costo) : 0} </td>
+            <td>${(json_producto['tipo_iva'] == 5) ? formatearNumero(cantidad * costo) : 0} </td>
+            <td>${(json_producto['tipo_iva'] == 10) ? formatearNumero(cantidad * costo) : 0} </td>
             <td>
                 <button class="btn btn-danger remover-item-factura_compra">Remover</button>
             </td>

--- a/vista/insumo.js
+++ b/vista/insumo.js
@@ -37,7 +37,7 @@ function mostrarAgregarInsumo() {
     let contenido = dameContenido("paginas/referenciales/insumo/agregar.php");
     $(".contenido-principal").html(contenido);
     cargarListaMarca("#marca_insumo");
-    cargarListaImpuesto("#impuesto_insumo");
+    cargarListaTipoIva("#tipo_iva_insumo");
 
     //obtener ultimo id
     let ultimo = ejecutarAjax("controladores/insumo.php", "ultimo_registro=1");
@@ -66,16 +66,10 @@ function cargarListaMarca(componente) {
     $(componente).html(option);
 }
 
-function cargarListaImpuesto(componente) {
-    let datos = ejecutarAjax("controladores/insumo.php", "leer_activos_impuesto=1");
-    console.log(datos);
-    let option = "<option value='0'>Selecciona un impuesto</option>";
-    if (datos !== "0") {
-        let json_datos = JSON.parse(datos);
-        json_datos.map(function (item) {
-            option += `<option value='${item.cod_impuesto}'>${item.descripcion}</option>`;
-        });
-    }
+function cargarListaTipoIva(componente) {
+    let option = "<option value='0'>Exento</option>";
+    option += "<option value='5'>I.V.A. 5%</option>";
+    option += "<option value='10'>I.V.A. 10%</option>";
     $(componente).html(option);
 }
 
@@ -90,8 +84,8 @@ function guardarInsumo() {
         mensaje_dialogo_info_ERROR("Debes seleccionar una marca", "ATENCION");
         return;
     }
-    if ($("#impuesto_insumo").val() === "0") {
-        mensaje_dialogo_info_ERROR("Debes seleccionar un impuesto", "ATENCION");
+    if ($("#tipo_iva_insumo").val() === "0") {
+        mensaje_dialogo_info_ERROR("Debes seleccionar un tipo de IVA", "ATENCION");
         return;
     }
 
@@ -110,7 +104,7 @@ function guardarInsumo() {
             'cod_insumos': $("#cod").val(),
             'descripcion': $("#descripcion_lst").val(),
             'cod_marca_insumos': $("#marca_insumo").val(),
-            'cod_impuesto': $("#impuesto_insumo").val(),
+            'tipo_iva': $("#tipo_iva_insumo").val(),
             'cantidad': $("#cantidad_txt").val(),
             'estado_insumos': 'ACTIVO',
             'costo': quitarDecimalesConvertir($("#costo_txt").val()),
@@ -127,7 +121,7 @@ function guardarInsumo() {
             'cod_insumos': $("#id_insumo").val(),
             'descripcion': $("#descripcion_lst").val(),
             'cod_marca_insumos': $("#marca_insumo").val(),
-            'cod_impuesto': $("#impuesto_insumo").val(),
+            'tipo_iva': $("#tipo_iva_insumo").val(),
             'cantidad': $("#cantidad_txt").val(),
             'estado_insumos': 'ACTIVO',
             'costo': quitarDecimalesConvertir($("#costo_txt").val()),
@@ -159,7 +153,7 @@ function cargarTablaInsumo() {
             fila += `<td>${item.cod_insumos}</td>`;
             fila += `<td>${item.descripcion}</td>`;
             fila += `<td>${item.descripcion_marca}</td>`;
-            fila += `<td>${item.des_imp}</td>`;
+            fila += `<td>${descripcionTipoIva(item.tipo_iva)}</td>`;
             fila += `<td>${formatearNumero(item.precio)}</td>`;
             fila += `<td><span class="badge badge-${(item.estado_insumos === "ACTIVO") ? 'success' : (item.estado_insumos === "DESACTIVADO") ? 'danger' : 'success'}">${item.estado_insumos}</span></td>`;
             fila += `<td>
@@ -172,6 +166,16 @@ function cargarTablaInsumo() {
     }
 
     $("#insumo_compra").html(fila);
+}
+
+function descripcionTipoIva(valor) {
+    if (valor == 10 || valor === '10') {
+        return 'I.V.A. 10%';
+    }
+    if (valor == 5 || valor === '5') {
+        return 'I.V.A. 5%';
+    }
+    return 'EXENTO';
 }
 
 $(document).on("keyup", "#costo_txt, #precio_txt", function (evt) {
@@ -234,7 +238,7 @@ $(document).on("click", ".editar-insumo", function (evt) {
                 let contenido = dameContenido("paginas/referenciales/insumo/agregar.php");
                 $(".contenido-principal").html(contenido);
                 cargarListaMarca("#marca_insumo");
-                cargarListaImpuesto("#impuesto_insumo");
+                cargarListaTipoIva("#tipo_iva_insumo");
 
 
                 //cargar los datos
@@ -243,7 +247,7 @@ $(document).on("click", ".editar-insumo", function (evt) {
                 $("#id_insumo").val(json_registro['cod_insumos']);
                 $("#descripcion_lst").val(json_registro['descripcion']);
                 $("#marca_insumo").val(json_registro['cod_marca_insumos']);
-                $("#impuesto_insumo").val(json_registro['cod_impuesto']);
+                $("#tipo_iva_insumo").val(json_registro['tipo_iva']);
                 $("#cantidad_txt").val(json_registro['cantidad']);
                 $("#costo_txt").val(formatearNumero(json_registro['costo']));
                 $("#precio_txt").val(formatearNumero(json_registro['precio']));

--- a/vista/nota_credito_compra.js
+++ b/vista/nota_credito_compra.js
@@ -308,7 +308,7 @@ $(document).on("change", "#facturas_compra_lst", function (evt) {
                         <td>${formatearNumero(item.exenta)}</td>
                         <td>${formatearNumero(item.iva5)}</td>
                         <td>${formatearNumero(item.iva10)}</td>
-                        <td hidden>${(item.cod_impuesto)}</td>
+                        <td hidden>${(item.tipo_iva)}</td>
                          <td><input type="checkbox" class="seleccion-nota"></td>
                     </tr>
                 `);
@@ -325,13 +325,13 @@ $(document).on("change", ".cantidad-nota", function (evt) {
     let costo = quitarDecimalesConvertir($(this).closest("tr").find("td:eq(2)").text());
     let impuesto = $(this).closest("tr").find("td:eq(7)").text();
 
-    if (impuesto === "3") {
+    if (impuesto === "0") {
         $(this).closest("tr").find("td:eq(4)").text(formatearNumero(costo * cantidad));
     }
-    if (impuesto === "2") {
+    if (impuesto === "5") {
         $(this).closest("tr").find("td:eq(5)").text(formatearNumero(costo * cantidad));
     }
-    if (impuesto === "1") {
+    if (impuesto === "10") {
         $(this).closest("tr").find("td:eq(6)").text(formatearNumero(costo * cantidad));
     }
     calcularTotalNotaCreditoCompra();


### PR DESCRIPTION
## Summary
- capture product IVA type with new `tipo_iva` field and selector
- calculate purchase invoice taxes using product IVA value
- include IVA type in database schema and related reports

## Testing
- `php -l controladores/insumo.php`
- `php -l controladores/factura_compra_detalle.php`
- `php -l paginas/referenciales/insumo/agregar.php`
- `php -l paginas/referenciales/insumo/listar.php`
- `php -l paginas/movimientos/compra/factura_compra/print.php`
- `php -l paginas/movimientos/compra/nota_credito/print.php`
- `node --check vista/insumo.js`
- `node --check vista/factura_compra.js`
- `node --check vista/nota_credito_compra.js`


------
https://chatgpt.com/codex/tasks/task_e_688fb86dfaf88333985a1849a686c29b